### PR TITLE
Remove deprecated config_file from linter.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -24,7 +24,6 @@ class MarkdownLint(NodeLinter):
                     'text.html.markdown.gfm'
     }
     cmd = ('markdownlint', '${args}', '${file}')
-    config_file = ('--config', '.markdownlintrc')
     regex = r'.+?[:]\s(?P<line>\d+)[:]\s(?P<error>MD\d+)?[/]?(?P<message>.+)'
     multiline = False
     line_col_base = (1, 1)


### PR DESCRIPTION
Fix this warning:

```
reloading plugin SublimeLinter-contrib-markdownlint.linter
markdownlint: Defining 'cls.config_file' has no effect. Please cleanup and remove this setting.
```