### PR TITLE
Fixing broken regex for markdownlint-cli 0.19.0 compatibility

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -24,7 +24,7 @@ class MarkdownLint(NodeLinter):
                     'text.html.markdown.gfm'
     }
     cmd = ('markdownlint', '${args}', '${file}')
-    regex = r'.+?[:]\s(?P<line>\d+)[:]\s(?P<error>MD\d+)?[/]?(?P<message>.+)'
+    regex = r'.+?[:](?P<line>\d+)\s(?P<error>MD\d+)?[/]?(?P<message>.+)'
     multiline = False
     line_col_base = (1, 1)
     tempfile_suffix = '-'


### PR DESCRIPTION
Hi,

Since the last update of `markdownlint-cli (0.19.0)` it seems that the linter does not work anymore.
The current regexp does not match with the new markdownlint-cli output format, with debug mode enabled in SublimeLinter I can see parsing errors on each line returned by cli like : 

```text
SublimeLinter: #9 linter.py:1230      markdownlint: No match for line: '/path/to/the/markdown.md:xxx MDxxx/message'
```

I updated the regexp and hot tested with the ST plugin `PackageResourceViewer` and it works perfectly.
