### PR TITLE
Fix Windows compatibility

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -12,10 +12,17 @@
 """This module exports the Markdownlint plugin class."""
 
 from SublimeLinter.lint import NodeLinter, util
+import sublime
 
 
 class MarkdownLint(NodeLinter):
     """Provides an interface to markdownlint."""
+
+    # there is a ":" in the file path under Windows like C:\DIR\FILE
+    if sublime.platform() == "windows":
+        file_regex = r"[^:]+:[^:]+"
+    else:
+        file_regex = r"[^:]+"
 
     defaults = {
         'selector': 'text.html.markdown,'
@@ -24,7 +31,7 @@ class MarkdownLint(NodeLinter):
                     'text.html.markdown.gfm'
     }
     cmd = ('markdownlint', '${args}', '${file}')
-    regex = r'.+?[:](?P<line>\d+)\s(?P<error>MD\d+)?[/]?(?P<message>.+)'
+    regex = r'(?P<file>{0})[:]\s*(?P<line>\d+):\s+(?P<error>MD\d+)?[/]?(?P<message>.+)'.format(file_regex)
     multiline = False
     line_col_base = (1, 1)
     tempfile_suffix = '-'


### PR DESCRIPTION
Under Windows, the file path has a `:` in it hence the current regex won't work.

Here's the debug raw output from SublimeLinter.

```
SublimeLinter: #1 linter.py:1178      markdownlint: output:
  C:\Users\XXXXXX\Desktop\a.md: 1: MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 4]
```

I have the same fix for my another linter years ago.
https://github.com/jfcherng/SublimeLinter-contrib-iverilog/pull/1#issuecomment-108582583